### PR TITLE
add in groups

### DIFF
--- a/package.json
+++ b/package.json
@@ -1687,7 +1687,7 @@
             ],
             "description": "R code to be executed"
           },
-          "args": {
+          "options": {
             "type": "array",
             "items": {
               "type": "string"
@@ -1696,7 +1696,7 @@
               "--no-echo",
               "--no-restore"
             ],
-            "description": "Arguments used to invoke R (see R --help)"
+            "description": "Command line options used to invoke R (see R --help)"
           },
           "cwd": {
             "type": "string",

--- a/package.json
+++ b/package.json
@@ -1674,20 +1674,15 @@
     "taskDefinitions": [
       {
         "type": "R",
-        "required": ["command", "args"],
+        "required": ["code"],
         "properties": {
-          "command": {
-            "type": "string",
-            "default": "Rscript",
-            "description": "The command to be executed."
-          },
-          "args": {
+          "code": {
             "type": "array",
             "items": {
               "type": "string"
             },
             "default": [],
-            "description": "The command arguments."
+            "description": "R code to be executed"
           },
           "cwd": {
             "type": "string",

--- a/package.json
+++ b/package.json
@@ -1681,8 +1681,22 @@
             "items": {
               "type": "string"
             },
-            "default": [],
+            "default": [
+              "x <- 'Hello, World!'",
+              "print(x)"
+            ],
             "description": "R code to be executed"
+          },
+          "args": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "default": [
+              "--no-echo",
+              "--no-restore"
+            ],
+            "description": "Arguments used to invoke R (see R --help)"
           },
           "cwd": {
             "type": "string",

--- a/src/tasks.ts
+++ b/src/tasks.ts
@@ -76,6 +76,11 @@ const asTask = function (
     folder: vscode.WorkspaceFolder | vscode.TaskScope,
     meta: TaskMeta
 ): vscode.Task {
+    const codeLines: string[] = [];
+    for (const line of meta.definition.code) {
+        codeLines.push('-e');
+        codeLines.push(line);
+    }
     const task: vscode.Task = new vscode.Task(
         meta.definition,
         folder,
@@ -83,7 +88,7 @@ const asTask = function (
         TYPE,
         new vscode.ProcessExecution(
             'Rscript',
-            ['-e', meta.definition.code.join('; ')],
+            codeLines,
             {
                 cwd: meta.definition.cwd,
                 env: meta.definition.env

--- a/src/tasks.ts
+++ b/src/tasks.ts
@@ -115,8 +115,8 @@ export class RTaskProvider implements vscode.TaskProvider {
         const tasks: vscode.Task[] = [];
         
         for (const folder of folders) {
-            const is_r_workspace = fs.existsSync(path.join(folder.uri.fsPath, 'DESCRIPTION'));
-            if (is_r_workspace) {
+            const isRPackage = fs.existsSync(path.join(folder.uri.fsPath, 'DESCRIPTION'));
+            if (isRPackage) {
                 for (const rtask of rtasks) {
                     const task = asTask(folder, rtask);
                     tasks.push(task);

--- a/src/tasks.ts
+++ b/src/tasks.ts
@@ -102,6 +102,8 @@ const asTask = function (
 
 
 export class RTaskProvider implements vscode.TaskProvider {
+    
+    public type = TYPE;
 
     public provideTasks(): vscode.Task[] {        
         const folders = vscode.workspace.workspaceFolders;

--- a/src/tasks.ts
+++ b/src/tasks.ts
@@ -67,7 +67,7 @@ const rtasks: TaskMeta[] = [
             type: TYPE,
             code: [ 'devtools::install()' ]
         },
-        vscode.TaskGroup.Test
+        vscode.TaskGroup.Build
     )
 ];
 

--- a/src/tasks.ts
+++ b/src/tasks.ts
@@ -1,6 +1,8 @@
 'use strict';
 
 import * as vscode from 'vscode';
+import * as fs from 'fs';
+import * as path from 'path';
 
 interface RTaskDefinition extends vscode.TaskDefinition {
     command: string;
@@ -103,8 +105,23 @@ export class RTaskProvider implements vscode.TaskProvider {
         ),
     ];
 
-    public provideTasks(): vscode.Task[] {
-        return this.tasks;
+    public provideTasks(): vscode.Task[] {        
+        const folders = vscode.workspace.workspaceFolders;
+        
+        if (!folders) {
+            return [] as vscode.Task[];
+        }
+        
+        let is_r_workspace: boolean;
+        for(const folder of folders){
+            is_r_workspace = fs.existsSync(
+                path.join(folder.uri.fsPath, 'DESCRIPTION')
+            );
+        }
+        if (is_r_workspace){
+            return this.tasks;
+        }
+        return undefined;
     }
 
     public resolveTask(task: vscode.Task): vscode.Task {

--- a/src/tasks.ts
+++ b/src/tasks.ts
@@ -12,8 +12,8 @@ interface RTaskDefinition extends vscode.TaskDefinition {
 export class RTaskProvider implements vscode.TaskProvider {
     public readonly type = 'R';
 
-    private getTask(name: string, definition: RTaskDefinition, problemMatchers?: string | string[]): vscode.Task {
-        return new vscode.Task(
+    private getTask(name: string, definition: RTaskDefinition, group?: vscode.TaskGroup, problemMatchers?: string | string[]): vscode.Task {
+        const task: vscode.Task = new vscode.Task(
             definition,
             vscode.TaskScope.Workspace,
             name,
@@ -28,49 +28,79 @@ export class RTaskProvider implements vscode.TaskProvider {
             ),
             problemMatchers
         );
+        
+        if (group) {
+            task.group = group;
+        }
+        
+        return task;
     }
 
     private readonly tasks = [
-        this.getTask('Build', {
-            type: this.type,
-            command: 'Rscript',
-            args: [
-                '-e',
-                'devtools::build()'
-            ]
-        }),
-        this.getTask('Check', {
-            type: this.type,
-            command: 'Rscript',
-            args: [
-                '-e',
-                'devtools::check()'
-            ]
-        }),
-        this.getTask('Document', {
-            type: this.type,
-            command: 'Rscript',
-            args: [
-                '-e',
-                'devtools::document()'
-            ]
-        }),
-        this.getTask('Install', {
-            type: this.type,
-            command: 'Rscript',
-            args: [
-                '-e',
-                'devtools::install()'
-            ]
-        }),
-        this.getTask('Test', {
-            type: this.type,
-            command: 'Rscript',
-            args: [
-                '-e',
-                'devtools::test()'
-            ]
-        }, '$testthat'),
+        this.getTask(
+            'Build',
+            {
+                type: this.type,
+                command: 'Rscript',
+                args: [
+                    '-e',
+                    'devtools::build()'
+                ]
+            },
+            vscode.TaskGroup.Build
+        ),
+
+        this.getTask(
+            'Check',
+            {
+                type: this.type,
+                command: 'Rscript',
+                args: [
+                    '-e',
+                    'devtools::check()'
+                ]
+            },
+            vscode.TaskGroup.Test,
+        ),
+
+        this.getTask(
+            'Document',
+            {
+                type: this.type,
+                command: 'Rscript',
+                args: [
+                    '-e',
+                    'devtools::document()'
+                ]
+            }
+        ),
+
+        this.getTask(
+            'Install',
+            {
+                type: this.type,
+                command: 'Rscript',
+                args: [
+                    '-e',
+                    'devtools::install()'
+                ]
+            },
+            vscode.TaskGroup.Build
+        ),
+
+        this.getTask(
+            'Test',
+            {
+                type: this.type,
+                command: 'Rscript',
+                args: [
+                    '-e',
+                    'devtools::test()'
+                ]
+            },
+            vscode.TaskGroup.Test, 
+            '$testthat'
+        ),
     ];
 
     public provideTasks(): vscode.Task[] {
@@ -81,6 +111,7 @@ export class RTaskProvider implements vscode.TaskProvider {
         return this.getTask(
             task.name,
             <RTaskDefinition>task.definition,
+            task.group,
             task.problemMatchers
         );
     }


### PR DESCRIPTION
In this PR I added:
- Support for multi folder workspaces
- Added categorisation for "Build" and "Test" commands
- Added dynamic processing to only load tasks if in a project containing a `DESCRIPTION` file
- Changed the Task definition so it can be written purely in R code 

For the last 2 point please see my comment below

EDIT: Just to say I'm not precious about the formatting or engineering so feel free to change completely if you don't like the way I've styled / laid it out!
